### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/neo4j-store.js
+++ b/neo4j-store.js
@@ -10,7 +10,7 @@
 
 var _ = require('lodash')
 var Request = require('request')
-var Uuid = require('node-uuid')
+var Uuid = require('uuid')
 var DefaultConfig = require('./config/default_config.json')
 var StatementBuilder = require('./lib/statement-builder.js')
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "main": "neo4j-store.js",
   "license": "MIT",
   "author": "Paul Nebel <paul@nebel.io> (http://www.paulnebel.io)",
-  "contributors" :[{
-    "name": "Michele Capra",
-    "email": "michelecapra83@gmail.com"
-  }],
+  "contributors": [
+    {
+      "name": "Michele Capra",
+      "email": "michelecapra83@gmail.com"
+    }
+  ],
   "bugs": {
     "url": "https://github.com/DogFishProductions/seneca-neo4j-store/issues"
   },
@@ -61,10 +63,10 @@
     "seneca-entity": "0.0.1"
   },
   "dependencies": {
+    "lodash": "^4.12.0",
     "q": "^1.4.1",
     "request": "^2.69.0",
-    "lodash": "^4.12.0",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   },
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.